### PR TITLE
add gradle ci flow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -28,19 +28,3 @@ jobs:
           build-root-directory: hyperloglog
       - name: Build with Gradle Wrapper
         run: ./gradlew build
-
-  dependency-submission:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-      - name: Generate and submit dependency graph
-        uses: gradle/actions/dependency-submission@af1da67850ed9a4cedd57bfd976089dd991e2582
-        with:
-          build-root-directory: hyperloglog


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for continuous integration of the Java project using Gradle. The workflow automates building the project and submitting dependency information on pushes and pull requests to the main branch.

CI/CD automation:

* Added `.github/workflows/gradle.yml` to set up a Java CI pipeline with Gradle, including steps for checking out code, setting up JDK 21, configuring Gradle, building the project, and submitting dependency graphs.